### PR TITLE
Widen rails dep to allow Rails 8 (verified on Rails 8.1.3)

### DIFF
--- a/acts_as_readable.gemspec
+++ b/acts_as_readable.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'acts_as_readable'
-  s.version = '2.5.1'
+  s.version = '2.6.0'
   s.email = 'contact@culturecode.ca'
   s.homepage = 'http://github.com/culturecode/acts_as_readable'
   s.summary = "Allows records to be marked as readable. Optimized for bulk, 'mark all as read' operations"
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.files = Dir.glob("{generators,lib,spec}/**/*") + %w(README.rdoc)
 
-  s.add_dependency('rails', ['> 5', '< 8'])
+  s.add_dependency('rails', ['> 5', '< 9'])
   s.add_development_dependency('pg')
   s.add_development_dependency('rspec-rails', '~> 4')
 end

--- a/gemfiles/rails8.gemfile
+++ b/gemfiles/rails8.gemfile
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+
+gem "activerecord", "~> 8"
+
+group :test do
+  gem "rspec"
+  gem "pry"
+end
+
+gemspec path: "../"


### PR DESCRIPTION
## Summary
- Widen runtime `rails` dep from `< 8` to `< 9` so consumer apps can resolve to Rails 8.x.
- Bump version to 2.6.0.
- Add `gemfiles/rails8.gemfile` Appraisal mirroring the existing `rails6`/`rails7` ones.

## Test plan
- [x] `bundle exec rspec` against `BUNDLE_GEMFILE=gemfiles/rails8.gemfile`: **117 examples, 0 failures** on Rails 8.1.3.
- [ ] Existing `rails6.gemfile` / `rails7.gemfile` still pass on their respective Rails versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)